### PR TITLE
Feature/7 add clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1.37.0" }
 tokio-util = { version = "0.7.10" }
 axum = "0.7.5"
 #shiva = {path = "../shiva/lib"}
-shiva = "1.1.1"
+shiva = "=1.3.0"
 metatron = { path = "crates/libs/metatron" }
 kdl = "4.6.0"
 serde = { version = "1.0.198" }

--- a/crates/services/metatron-server/Cargo.toml
+++ b/crates/services/metatron-server/Cargo.toml
@@ -28,6 +28,7 @@ metatron = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing = { workspace = true }
 mime = { workspace = true }
+clap = { workspace = true }
 
 [dev-dependencies]
 http = { workspace = true }

--- a/crates/services/metatron-server/src/main.rs
+++ b/crates/services/metatron-server/src/main.rs
@@ -1,8 +1,33 @@
 use metatron_server::router;
+use clap::Parser;
+
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "metatron",
+    author,
+    version,
+    about = "Metatron: Implementation in Rust of a report generation based on Shiva library",
+    long_about = None
+)]
+struct Args {
+    #[arg(
+        short,
+        long, 
+        default_value_t = 3000, 
+        help = "The port number to bind the server to",
+    )]
+    port: u16,
+}
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+
+    let args = Args::parse();
+
+    let address = format!("0.0.0.0:{}", args.port);
+
+    let listener = tokio::net::TcpListener::bind(&address).await.unwrap();
     axum::serve(listener, router()).await.unwrap();
 }

--- a/crates/services/metatron-server/src/main.rs
+++ b/crates/services/metatron-server/src/main.rs
@@ -27,7 +27,7 @@ async fn main() {
     let args = Args::parse();
 
     let address = format!("0.0.0.0:{}", args.port);
-
+    println!("Listening on {}", address);
     let listener = tokio::net::TcpListener::bind(&address).await.unwrap();
     axum::serve(listener, router()).await.unwrap();
 }


### PR DESCRIPTION
Closes #7

- Added clap to metatron server
- Supports -p and --port flag to bind port to tcp listener.
- If the flag is not provided fallbacks to default.